### PR TITLE
add missing dependency to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,3 +54,4 @@ sudo cp manga-cli /usr/local/bin/manga-cli
 - patch
 - convert
 - zathura
+- zathura-pdf-mupdf


### PR DESCRIPTION
zathura requires [`zathura-pdf-mupdf`](https://git.pwmt.org/pwmt/zathura-pdf-mupdf) in order to display pdf files. 