### PR TITLE
Changed dependencies to the actual package name

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,13 +57,11 @@ sudo cp manga-cli /usr/local/bin/manga-cli
 
 ## Dependencies
 
-- GNU coreutils (ls, tr, rm, cat, mkdir)
+- coreutils
 - curl
 - sed
 - awk
-- du
-- git
-- diff
+- diffutils
 - patch
 - img2pdf
 - zathura

--- a/manga-cli
+++ b/manga-cli
@@ -499,3 +499,4 @@ case "${1}" in
 		manga_title_input="${*}"
 		main
 esac
+


### PR DESCRIPTION
# Problem
Instead of the package name the command name was listed in the dependencies of the README, this made it hard for users to install them because they couldn't simply copy and paste them. 

# Example
`sudo pacman -S diff`

This command would return 

`error: target not found: diff`

# Solution
All the dependencies ***only*** in the README were replaced with their respective packagenames.

`diff` --> `diffutils`