### PR TITLE
fix fullscreen help

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Options:
 	-h, --help		Print this help page
 	-V, --version		Print version number
 	-u, --update		Fetch latest version from the Github repository
-	-f, --fullscreen	Open Zathura in fullscreen mode by default
+	-f, --fullscreen	Open Zathura in fullscreen mode 
 	-l, --last-session    	Open last session
 	-c, --cache-size	Print cache size ($HOME/.cache/manga-cli)
 	-C, --clear-cache	Clear cache ($HOME/.cache/manga-cli)

--- a/manga-cli
+++ b/manga-cli
@@ -60,7 +60,7 @@ show_help() {
 	  -h, --help		Print this help page
 	  -V, --version		Print version number
 	  -u, --update		Fetch latest version from the Github repository
-	  -f, --fullscreen	Open Zathura in fullscreen mode by default
+	  -f, --fullscreen	Open Zathura in fullscreen mode 
 	  -l, --last-session	Open last session
 	  -c, --cache-size	Print cache size (${cache_dir})
 	  -C, --clear-cache	Clear cache (${cache_dir})


### PR DESCRIPTION
> "the default" always is to open it in non fullscreen mode
-f only makes it open in fullscreen that session so i think saying by default is kinda wrong

...so i deleted it!