### PR TITLE
Add more feature flags

### DIFF
--- a/manga-cli
+++ b/manga-cli
@@ -3,7 +3,11 @@
 version="1.0.5"
 old_ifs="${IFS}"
 cache_dir="${HOME}/.cache/manga-cli"
-dependencies=("ls" "cat" "curl" "sed" "awk" "tr" "du" "rm" "mkdir" "git" "diff" "patch" "img2pdf" "zathura")
+
+base_dependencies=("ls" "cat" "curl" "sed" "awk" "tr" "du" "rm" "mkdir" "git" "diff" "patch")
+pdf_dependencies=("img2pdf")
+read_dependencies=("zathura")
+
 github_source="https://raw.githubusercontent.com/7USTIN/manga-cli/master/manga-cli"
 
 # Text colors
@@ -434,12 +438,21 @@ convert_imgs_to_pdf() {
 
 open_chapter() {
 	scrape_chapter
-	convert_imgs_to_pdf
+
+	if [[ "${pdf_output}" == "true" ]]; then
+		convert_imgs_to_pdf
+	fi
+
+	if [[ "${download_only}" == "true" ]]; then
+		return 
+	fi
+
 	open_pdf
 	cache_session
 }
 
 check_dependencies() {
+	local dependencies=("$@")
 	for dependency in "${dependencies[@]}"; do
 		if ! command -v "${dependency}" &> /dev/null; then
 			if ! pip3 show "${dependency}" &> /dev/null; then
@@ -463,7 +476,7 @@ check_dependencies() {
 # Call 'reset_ifs' function when exiting script
 trap reset_ifs EXIT
 
-check_dependencies
+check_dependencies "${base_dependencies[@]}"
 
 main() {
 	search_manga
@@ -504,6 +517,12 @@ while [[ "${1}" ]]; do
 			clear_cache
 			exit 0
 			;;
+		-d|--download)
+			download_only=true
+			;;
+		-i|--image-output)
+			pdf_output=false
+			;;
 		*)	
 			show_help
 			exit 1
@@ -512,6 +531,14 @@ while [[ "${1}" ]]; do
 
 	shift
 done
+
+if [[ "${download_only}" != "true" ]]; then
+	check_dependencies "${read_dependencies[@]}"
+fi
+
+if [[ "${pdf_output}" != "false" ]]; then
+	check_dependencies "${pdf_dependencies[@]}"
+fi
 
 if [[ "${open_last_session}" == "true" ]]; then
 	open_chapter

--- a/manga-cli
+++ b/manga-cli
@@ -76,7 +76,18 @@ show_version() {
 	print_green "Version: ${version}"
 }
 
-open_pdf() { # Open PDF using Zathura and run it in the background
+open_pdf() { 
+	if [[ -n "${reader}" ]]; then
+		if [[ -f "${pdf_dir}" ]]; then 
+			eval "${reader} ${pdf_dir}"
+		else
+			eval "${reader} ${image_dir}/*.jpg"
+		fi
+
+		return $?
+	fi
+
+	# Fallback to Zathura
 	if [[ "${zathura_auto_fullscreen}" == "true" ]]; then
 		zathura --page=1 --mode="fullscreen" "${pdf_dir}" &
 	else
@@ -523,6 +534,10 @@ while [[ "${1}" ]]; do
 		-i|--image-output)
 			pdf_output=false
 			;;
+		-r|--reader)
+			reader="$2"
+			shift
+			;;
 		*)	
 			show_help
 			exit 1
@@ -532,7 +547,7 @@ while [[ "${1}" ]]; do
 	shift
 done
 
-if [[ "${download_only}" != "true" ]]; then
+if [[ "${download_only}" != "true" && -z "${reader}" ]]; then
 	check_dependencies "${read_dependencies[@]}"
 fi
 

--- a/manga-cli
+++ b/manga-cli
@@ -4,9 +4,10 @@ version="1.0.5"
 old_ifs="${IFS}"
 cache_dir="${HOME}/.cache/manga-cli"
 
-base_dependencies=("ls" "cat" "curl" "sed" "awk" "tr" "du" "rm" "mkdir" "git" "diff" "patch")
+base_dependencies=("ls" "cat" "curl" "sed" "awk" "tr" "du" "rm" "mkdir")
 pdf_dependencies=("img2pdf")
 read_dependencies=("zathura")
+update_dependencies=("diff" "patch")
 
 github_source="https://raw.githubusercontent.com/7USTIN/manga-cli/master/manga-cli"
 
@@ -516,6 +517,7 @@ while [[ "${1}" ]]; do
 			exit 0
 			;;
 		-u|--update)
+			check_dependencies "${update_dependencies[@]}"
 			update_script
 			exit 0
 			;;

--- a/manga-cli
+++ b/manga-cli
@@ -325,12 +325,18 @@ scrape_chapter() {
 		for image_src in "${chapter_image_urls[@]}"; do
 			((i=i + 1))
 
+			local image_name="${image_dir}/${i}.jpg" 
+
+			if [[ -f "${image_name}" ]]; then 
+				continue
+			fi
+
 			# Download image in the background
 			curl \
 				--silent \
 				--create-dirs \
 				--header 'Referer: https://readmanganato.com/' \
-				--output "${image_dir}/${i}.jpg" \
+				--output "${image_name}" \
 				"${image_src}" &
 		done
 


### PR DESCRIPTION
Adds more feature flag for a more flexible usage:
* add `-d, --download-only` to only download the images
* add `-i, image-output` to keep images instead of converting to pdf
* add `-r, reader` to allow user to specify their own reader

Following this changes, we no longer require all the dependencies to be needed.
They are extracted and only checked if their relevant flags are toggled